### PR TITLE
chore: update dependency minidump to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt": "^0.4.5",
     "jade": "~0.35.0",
     "method-override": "^2.3.5",
-    "minidump": "0.3.0",
+    "minidump": "0.19.0",
     "mkdirp": "~0.3.5",
     "node-uuid": "~1.4.1",
     "temp": "0.7.0",


### PR DESCRIPTION
fixes:
even when i placed my symbol files in pool/symbols with right directory hierarchy, mini-breakpad-server still said "no symbols". and in the crashed thread stacktrace, there are no function names , this makes debug harder.

env:
minidump files are generated by my electron 8.1.0 based app.
symbol files are generated by  `dump_syms`
using `minidump_stackwalk`  function names will be showed along with stacktrace, but without this PR, there are no function names.
